### PR TITLE
Allow Into<Chain> for looping animations to be implemented by crate users

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ pub mod widget;
 mod keyframes;
 mod utils;
 
-pub use crate::keyframes::{cards, chain, id, lazy, toggler};
+pub use crate::keyframes::{cards, chain, id, lazy, toggler, Repeat};
 pub use crate::timeline::{Chain, Timeline};
 
 pub use cosmic::iced::time::{Duration, Instant};


### PR DESCRIPTION
Since `keyframes::Repeat` is private, currently there is no way to implement a looping animation with `Repeat::Forever` for a custom widget, only a oneshot animation with `Repeat::Never` by using `Default::default()`.