### PR TITLE
Adapt to `cosmic-text` changes

### DIFF
--- a/src/widget/cosmic_toggler.rs
+++ b/src/widget/cosmic_toggler.rs
@@ -174,7 +174,8 @@ where
                         self.text_alignment,
                         alignment::Vertical::Top,
                         self.text_shaping,
-                        cosmic::iced_core::text::Wrapping::default(),
+                        text::Wrapping::default(),
+                        text::Ellipsize::default(),
                     );
                     match self.width {
                         Length::Fill => {


### PR DESCRIPTION
This adds the Ellipsize field, so that things using this can compile successfully.